### PR TITLE
Update _chatListeners.mjs

### DIFF
--- a/scripts/_chatListeners.mjs
+++ b/scripts/_chatListeners.mjs
@@ -54,7 +54,7 @@ export function onClickButton(chatLog, html) {
     const body = `(
             ${args.action}
         )();`;
-    const fn = Function("token", "character", "actor", "scene", "event", "args", body);
+    const fn = Function("token", "character", "actor", "scene", "amount", "event", "args", body);
 
     // define helper variables.
     let character = game.user.character;
@@ -62,6 +62,16 @@ export function onClickButton(chatLog, html) {
     let actor = token?.actor ?? character;
     let scene = canvas?.scene;
 
+    let amount = "";
+    if ('amount' in args) {
+      amount = args.amount;
+    }
+
+    if ('actor_from_token_ID' in args) {
+      let target_token = canvas.tokens.get(args.actor_from_token_ID)
+      actor = target_token.actor;
+    }
+    
     // if button is unlimited, remove disabled attribute.
     if (limit === LIMIT.FREE) button.disabled = false;
 
@@ -91,7 +101,7 @@ export function onClickButton(chatLog, html) {
     delete THIS.label;
 
     // execute the embedded function.
-    return fn.call(THIS, token, character, actor, scene, event, THIS);
+    return fn.call(THIS, token, character, actor, scene, amount, event, THIS);
   });
 }
 


### PR DESCRIPTION
Added ability to utilize amount in embedded function and to change the actor referenced by the embedded function.

Use case:  The embedded function requires a change amount and the actor to which it will be applied.  The catch is that only the GM has permission to make this change.  Using the Requestor framework, an automated request is made to the GM with the amount and correct target set in the button as derived from the arguments.  This allows the GM to click the button to implement it (or ignore / delete with the trash icon).

Issues have been that the macro tries to use the GM as the actor (which fails) or references the player and so returns a permission error.  This is the first work-around I've found to automate the process.

```
action: async () => {
          await game.hm3.macros.changeFatigue(amount, actor)
        }
```
